### PR TITLE
Add automatic WireGuard restart for new clients

### DIFF
--- a/iac/user-data.yaml
+++ b/iac/user-data.yaml
@@ -278,11 +278,14 @@ write_files:
       # Generate QR code
       qrencode -t ansiutf8 < "${CLIENT_NAME}.conf"
 
+      # Restart WireGuard to apply the new peer
+      systemctl restart wg-quick@wg0
+
       echo ""
       echo "Client '$CLIENT_NAME' added successfully!"
       echo "Client IP: $CLIENT_IP"
       echo "Config file: ${CLIENT_NAME}.conf"
-      echo "Restart WireGuard: systemctl restart wg-quick@wg0"
+      echo "WireGuard restarted"
     owner: root:root
     permissions: "0755"
 


### PR DESCRIPTION
## Summary
- automatically restart WireGuard when a new client is added

## Testing
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713a12cd18832a8a0563a190ae097a