### PR TITLE
Clarify operational VPN script roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Cloud VPN Pi
+
+A Raspberry Pi–based VPN gateway with automation for provisioning cloud VPN endpoints, deploying Pi setup scripts, and controlling the gateway through a lightweight web UI. Use this repository to provision WireGuard servers in the cloud, manage client configs, and keep your Pi routing traffic through the desired location.
+
+## Repository layout
+
+- `clients/`: Utility scripts and stored WireGuard client configurations generated from cloud servers.
+- `iac/`: Terraform configuration for provisioning cloud infrastructure and WireGuard servers.
+- `pi/scripts/`: Host and Pi-side automation for configuring the Pi gateway and syncing configs.
+- `pi/web/`: Flask control panel that toggles the VPN and switches locations.
+
+## Quick start
+
+1. **Customize Pi settings**
+   - Edit `pi/scripts/config.sh` to match your LAN, SSH, and WireGuard preferences.
+   - Place VPN endpoint configs in `clients/configs/<location>-<device>.conf`.
+
+2. **Provision VPN endpoints (optional)**
+   - From `iac/`, run Terraform to create cloud instances and WireGuard servers. See `iac/README.md` for details.
+
+3. **Deploy to the Pi**
+   - From `pi/scripts/host/`, run `./deploy_to_pi.sh` to sync scripts, copy configs, and install the web UI service on the Pi.
+   - Use `./connect.sh` in the same directory for a configured SSH session.
+
+4. **Control the gateway**
+   - Visit the web UI (defaults to port `8080` on the Pi) to enable/disable the VPN or switch locations.
+   - You can also run Pi-side scripts in `pi/scripts/pi/` (e.g., `start_vpn.sh`, `stop_vpn.sh`, `setup_wireguard.sh`).
+
+## Docs per area
+
+- **Pi automation:** `pi/scripts/README.md`
+- **Web control panel:** `pi/web/README.md`
+- **Client management:** `clients/README.md`
+- **Infrastructure provisioning:** `iac/README.md`
+
+## Notes
+
+- The Pi scripts expect a Debian-based Pi with `iptables`, `dnsmasq`, and `WireGuard` available (handled by `setup_pi.sh`).
+- Ensure your router hands DHCP to the Pi so gateway and DNS settings propagate to clients.

--- a/iac/README.md
+++ b/iac/README.md
@@ -1,0 +1,33 @@
+# Infrastructure as Code (Terraform)
+
+This directory provisions cloud VPN endpoints (WireGuard servers) and supporting network resources. Outputs from Terraform are consumed by the client utilities and deployment scripts.
+
+## Files
+
+- `provider.tf` / `backend.tf`: Provider configuration and remote state backend.
+- `network.tf`: VPC/VNet, subnets, and security groups/firewall rules for WireGuard.
+- `compute.tf`: Virtual machine definition (includes user data for WireGuard setup).
+- `user-data.yaml`: Cloud-init template that installs WireGuard, configures the server, and exposes a management user.
+- `variables.tf` / `terraform.tfvars` (user-created): Input variables for regions, instance sizes, SSH keys, and endpoints.
+- `outputs.tf`: Values consumed by the `clients/` scripts (public IPs, VPN endpoints, SSH connection info).
+
+## Usage
+
+1. Configure your provider credentials (see `provider.tf`) and create a `terraform.tfvars` file that sets region, SSH key paths, and any per-location variables referenced in `variables.tf`.
+2. Initialize the workspace:
+   ```bash
+   terraform init
+   ```
+3. Review and apply changes:
+   ```bash
+   terraform plan
+   terraform apply
+   ```
+4. After apply, use the outputs to generate client configs or connect to instances (the `clients/add_client.sh` script reads these outputs automatically).
+
+## Cleanup
+
+Destroy the provisioned infrastructure when finished:
+```bash
+terraform destroy
+```

--- a/pi/scripts/README.md
+++ b/pi/scripts/README.md
@@ -71,6 +71,15 @@ Edit `config.sh` to customize for your environment.
    sudo ./setup_dnsmasq.sh
    ```
 
+3. **Operational commands:**
+
+   - `activate_vpn.sh <location>` installs the specified WireGuard profile onto the Pi, makes it the active config, then calls `start_vpn.sh`.
+   - `start_vpn.sh` starts the currently installed WireGuard profile and rewrites NAT rules; it assumes the config already exists in `/etc/wireguard`.
+   - `deactivate_vpn.sh` is a JSON-friendly wrapper that logs output and calls `stop_vpn.sh`.
+   - `stop_vpn.sh` stops the WireGuard unit, rewrites NAT rules for direct internet, and restores upstream DNS.
+
+   Use the wrappers when driving from the web UI or when you need to switch locations, and the `start_vpn.sh`/`stop_vpn.sh` pair for straight service control.
+
 ### Router
 
 - Disable the router's DHCP server so the Pi can provide leases that point


### PR DESCRIPTION
## Summary
- document how activate/deactivate wrappers differ from start/stop VPN scripts
- explain when to use each command for UI-driven versus direct service control

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69278f03d588832aa0069ae738327e72)