### PR TITLE
Add unbound-based DNS with VPN-aware upstream switching

### DIFF
--- a/pi/scripts/README.md
+++ b/pi/scripts/README.md
@@ -16,6 +16,7 @@ scripts/
 │   ├── setup_fail2ban.sh
 │   ├── setup_wireguard.sh
 │   ├── setup_gateway.sh
+│   ├── setup_unbound.sh
 │   └── setup_dnsmasq.sh
 └── README.md
 ```
@@ -28,7 +29,10 @@ All scripts use centralized configuration from `config.sh`. Key settings:
 - **WireGuard Configuration**: Interface name plus per-location configs stored in `../clients/configs/<location>-<device>.conf`. The deploy script copies every config to the Pi at `$WG_REMOTE_CONFIG_DIR`, `setup_wireguard.sh` syncs them into `$WG_CONFIG_ARCHIVE` (default `/etc/wireguard/configs`), records the active site in `$WG_ACTIVE_LOCATION_FILE`, and activates the location specified (defaults to `$WG_DEFAULT_LOCATION`).
 - **Network Configuration**: IP addresses and DHCP range (Pi hands out leases)
 - **fail2ban Configuration**: Ban times, retry limits
-- **DNS Configuration**: Upstream DNS server used by the Pi resolver
+- **DNS Configuration**: dnsmasq always forwards to the local Unbound resolver
+  on `127.0.0.1#5335`. Unbound switches upstreams automatically: it uses the
+  VPN-provided DNS when WireGuard is active, and falls back to
+  `UPSTREAM_DNS_SERVER` (default `1.1.1.1`) when the VPN is disabled.
 
 Edit `config.sh` to customize for your environment.
 
@@ -64,12 +68,13 @@ Edit `config.sh` to customize for your environment.
 2. **Individual components:**
    ```bash
    cd pi/
-   sudo ./install_packages.sh
-   sudo ./setup_fail2ban.sh
-    sudo ./setup_wireguard.sh frankfurt
-   sudo ./setup_gateway.sh
-   sudo ./setup_dnsmasq.sh
-   ```
+    sudo ./install_packages.sh
+    sudo ./setup_fail2ban.sh
+     sudo ./setup_wireguard.sh frankfurt
+    sudo ./setup_gateway.sh
+    sudo ./setup_unbound.sh
+    sudo ./setup_dnsmasq.sh
+    ```
 
 3. **Operational commands:**
 

--- a/pi/scripts/config.sh
+++ b/pi/scripts/config.sh
@@ -30,8 +30,10 @@ WG_STATE_FILE="/etc/wireguard/state"
 WG_INTERFACE="wg0"
 
 # DNS Configuration
-# Upstream resolver that dnsmasq forwards to while the Pi serves local DNS
-UPSTREAM_DNS_SERVER="192.168.2.1"
+# - LOCAL_DNS_SERVER is where dnsmasq forwards (Unbound on localhost by default)
+# - UPSTREAM_DNS_SERVER is the non-VPN resolver Unbound should use when VPN is off
+LOCAL_DNS_SERVER="127.0.0.1#5335"
+UPSTREAM_DNS_SERVER="1.1.1.1"
 DOMAIN_NAME="local"
 
 # Network Interface Configuration

--- a/pi/scripts/pi/install_packages.sh
+++ b/pi/scripts/pi/install_packages.sh
@@ -29,7 +29,8 @@ apt install -y \
     iptables-persistent \
     fail2ban \
     resolvconf \
-    dnsmasq
+    dnsmasq \
+    unbound
 
 # Clean up
 echo "🧹 Cleaning up..."

--- a/pi/scripts/pi/setup_dnsmasq.sh
+++ b/pi/scripts/pi/setup_dnsmasq.sh
@@ -73,8 +73,8 @@ log-dhcp
 # Cache size
 cache-size=1000
 
-# Upstream DNS server(s) dnsmasq will forward to
-server=$UPSTREAM_DNS_SERVER
+# Upstream DNS server(s) dnsmasq will forward to (Unbound by default)
+server=${LOCAL_DNS_SERVER:-127.0.0.1#5335}
 
 # Don't forward plain names
 domain-needed

--- a/pi/scripts/pi/setup_pi.sh
+++ b/pi/scripts/pi/setup_pi.sh
@@ -37,6 +37,7 @@ echo ""
 ./setup_fail2ban.sh
 ./setup_wireguard.sh
 ./setup_gateway.sh
+./setup_unbound.sh
 ./setup_dnsmasq.sh
 
 echo ""

--- a/pi/scripts/pi/setup_unbound.sh
+++ b/pi/scripts/pi/setup_unbound.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Script to configure Unbound as the local recursive/forwarding resolver
+# dnsmasq will forward all DNS queries to Unbound on localhost:5335
+
+set -euo pipefail
+
+# Check if we're running on a Pi
+if [ ! -f /proc/device-tree/model ] || ! grep -q "Raspberry Pi" /proc/device-tree/model 2>/dev/null; then
+    echo "❌ ERROR: This script should run on a Raspberry Pi!"
+    echo "You're currently on a different system. Please run this script on the Pi."
+    exit 1
+fi
+
+# Check if we're running as root/sudo
+if [ "$EUID" -ne 0 ]; then
+    echo "❌ ERROR: This script must be run as root (with sudo)"
+    echo "Usage: sudo ./setup_unbound.sh"
+    exit 1
+fi
+
+# Source centralized configuration
+if [ -f "config.sh" ]; then
+    # shellcheck disable=SC1091
+    source "config.sh"
+else
+    echo "❌ Configuration file 'config.sh' not found"
+    echo "Please make sure config.sh exists in the current directory"
+    exit 1
+fi
+
+if ! command -v unbound >/dev/null 2>&1; then
+    echo "❌ Error: unbound is not installed. Please run install_packages.sh first."
+    exit 1
+fi
+
+UNBOUND_CONF_DIR="/etc/unbound/unbound.conf.d"
+FORWARD_FILE="$UNBOUND_CONF_DIR/pi-forward.conf"
+DEFAULT_UPSTREAM="${UPSTREAM_DNS_SERVER:-1.1.1.1}"
+
+echo "⚙️  Configuring Unbound as local resolver on 127.0.0.1:5335..."
+
+mkdir -p "$UNBOUND_CONF_DIR"
+
+cat > "$UNBOUND_CONF_DIR/pi-gateway.conf" <<EOF_CONF
+server:
+    interface: 127.0.0.1
+    interface: $PI_IP
+    access-control: 127.0.0.0/8 allow
+    access-control: $PI_IP/32 allow
+    port: 5335
+    hide-identity: yes
+    hide-version: yes
+    qname-minimisation: yes
+    prefetch: yes
+
+include: "$FORWARD_FILE"
+EOF_CONF
+
+cat > "$FORWARD_FILE" <<EOF_FWD
+forward-zone:
+    name: "."
+    forward-addr: $DEFAULT_UPSTREAM
+EOF_FWD
+
+systemctl enable unbound
+systemctl restart unbound
+
+if systemctl is-active --quiet unbound; then
+    echo "✅ Unbound is running and listening on 127.0.0.1:5335"
+else
+    echo "❌ Unbound failed to start"
+    systemctl status unbound --no-pager -l || true
+    exit 1
+fi

--- a/pi/scripts/pi/start_vpn.sh
+++ b/pi/scripts/pi/start_vpn.sh
@@ -36,6 +36,9 @@ echo "🔄 Updating iptables for VPN routing..."
 iptables -t nat -F POSTROUTING
 iptables -t nat -A POSTROUTING -o $WG_INTERFACE -j MASQUERADE
 
+echo "🔄 Pointing Unbound at VPN DNS servers..."
+bash "$(dirname "$0")/update_unbound_upstream.sh" vpn
+
 echo "✅ VPN started! Pi gateway now routes traffic through the VPN."
 
 echo "Current NAT rules:"

--- a/pi/scripts/pi/update_unbound_upstream.sh
+++ b/pi/scripts/pi/update_unbound_upstream.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Update Unbound forwarders based on VPN state
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_PATH="$SCRIPT_DIR/config.sh"
+
+if [ -f "$CONFIG_PATH" ]; then
+    # shellcheck disable=SC1090
+    source "$CONFIG_PATH"
+fi
+
+WG_INTERFACE=${WG_INTERFACE:-wg0}
+WG_CONF="/etc/wireguard/${WG_INTERFACE}.conf"
+DEFAULT_UPSTREAM="${UPSTREAM_DNS_SERVER:-1.1.1.1}"
+UNBOUND_FORWARD_FILE="/etc/unbound/unbound.conf.d/pi-forward.conf"
+
+write_forwarders() {
+    local -a servers=("$@")
+
+    if [ ${#servers[@]} -eq 0 ] || [ -z "${servers[0]}" ]; then
+        servers=("$DEFAULT_UPSTREAM")
+    fi
+
+    mkdir -p "$(dirname "$UNBOUND_FORWARD_FILE")"
+
+    {
+        echo "forward-zone:"
+        echo "    name: \".\""
+        for server in "${servers[@]}"; do
+            # Convert dnsmasq-style host#port to unbound host@port if needed
+            server=${server//#/@}
+            echo "    forward-addr: ${server}"
+        done
+    } > "$UNBOUND_FORWARD_FILE"
+
+    systemctl reload unbound || systemctl restart unbound
+}
+
+vpn_dns_from_config() {
+    if [ ! -f "$WG_CONF" ]; then
+        return
+    fi
+
+    awk -F '=' '/^DNS/ {print $2}' "$WG_CONF" \
+        | tr ',' '\n' \
+        | tr -d '[:space:]' \
+        | sed '/^$/d'
+}
+
+MODE=${1:-""}
+
+if [ "$MODE" = "vpn" ]; then
+    mapfile -t dns_entries < <(vpn_dns_from_config)
+    write_forwarders "${dns_entries[@]}"
+else
+    write_forwarders "$DEFAULT_UPSTREAM"
+fi


### PR DESCRIPTION
## Summary
- add an Unbound setup step and point dnsmasq at the local resolver by default
- switch Unbound upstreams automatically based on VPN state using WireGuard DNS entries or a fallback
- update setup orchestration, package installs, and documentation for the new DNS flow

## Testing
- bash -n pi/scripts/pi/setup_unbound.sh
- bash -n pi/scripts/pi/update_unbound_upstream.sh
- bash -n pi/scripts/pi/start_vpn.sh
- bash -n pi/scripts/pi/stop_vpn.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69282783d650832aa59ce8d03d0fd497)